### PR TITLE
Fix counting bug in process_enrollments subroutine

### DIFF
--- a/process-enrollments.pl
+++ b/process-enrollments.pl
@@ -997,9 +997,9 @@ sub process_enrollments
 
 	if ($debug < 2)
 	{
-	    if (scalar(@enrollments_csv) > 1)
+	    if (scalar(@enrollments_csv) > 0)
 	    {
-			print "Submitting ",scalar(@enrollments_csv)-1," enrollment changes to Canvas in ",$batch+1," batches\n";
+			print "Submitting ",scalar(@enrollments_csv)," enrollment changes to Canvas in ",$batch+1," batches\n";
 			foreach $b (0..$batch)
 			{
 				my $json = rest_to_canvas("POSTRAW","/api/v1/accounts/2/sis_imports.json?extension=csv",$enrollment_csvs[$b]);


### PR DESCRIPTION
This fixes an issue in which enrollment changes are skipped if there is only one single entry in @enrollment_csv. Before changes were batched (see 6aef4c8bfaa093a7b448c89650c6eae753c6edbe), @enrollment_csv always started with the CSV header, which is why the `if` statement was checking for more than 1 item in @enrollments_csv. This is no longer the case and we don't have to subtract 1 to get the real count.

Test plan:

1. Create a section linked to an SIS ID
2. Run `process-enrollments.pl -f {sis_id}`
3. Verify that it output "Submitting 1 enrollment changes to Canvas"